### PR TITLE
fix: JWT updates with every request

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -106,10 +106,7 @@ class Api {
         if (!is_array($credentials))
             throw new Exception('Login requires first param to be an Associative Array');
 
-        $resp =  $this->post('v1/login', $credentials);
-        $jwt = $resp->headers['authorization'];
-        $this->setJwt($jwt);
-        return $resp;
+        return $this->post('v1/login', $credentials);
     }
 
     protected function buildUrl($path)
@@ -120,27 +117,52 @@ class Api {
 
     public function get($path)
     {
-        return Requests::get($this->buildUrl($path), $this->headers, $this->requestOptions);
+        return $this->handleRequest('get', $path);
     }
 
     public function post($path, $data)
     {
-        return Requests::post($this->buildUrl($path), $this->headers, $data, $this->requestOptions);
+        return $this->handleRequest('post', $path, $data);
     }
 
     public function put($path, $data)
     {
-        return Requests::put($this->buildUrl($path), $this->headers, $data, $this->requestOptions);
+        return $this->handleRequest('put', $path, $data);
     }
 
     public function patch($path, $data)
     {
-        return Requests::patch($this->buildUrl($path), $this->headers, $data, $this->requestOptions);
+        return $this->handleRequest('patch', $path, $data);
     }
 
     public function delete($path)
     {
-        return Requests::delete($this->buildUrl($path), $this->headers, $this->requestOptions);
+        return $this->handleRequest('delete', $path);
+    }
+
+    protected function handleRequest($method, $path, $data=[])
+    {
+        $resp;
+        switch($method) {
+            case 'get':
+                $resp = Requests::get($this->buildUrl($path), $this->headers, $this->requestOptions);
+                break;
+            case 'post':
+                $resp = Requests::post($this->buildUrl($path), $this->headers, $data, $this->requestOptions);
+                break;
+            case 'put':
+                $resp = Requests::put($this->buildUrl($path), $this->headers, $data, $this->requestOptions);
+                break;
+            case 'patch':
+                $resp = Requests::patch($this->buildUrl($path), $this->headers, $data, $this->requestOptions);
+                break;
+            case 'delete':
+                $resp = Requests::delete($this->buildUrl($path), $this->headers, $this->requestOptions);
+                break;
+        }
+        $jwt = $resp->headers['authorization'];
+        $this->setJwt($jwt);
+        return $resp;
     }
 
 }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -147,6 +147,21 @@ class ApiTest extends TestCase {
         $this->assertEquals($resp->body['options']['type'], 'POST');
     }
 
+    function testPostUpdatesJwt()
+    {
+        $transport = new MockTransport();
+        $jwt = 'mock.jsonwebtoken.aasdf';
+        $transport->raw_headers =  'authorization: ' . $jwt ."\r\n";
+        $transport->code = 201;
+        $api = new Api(self::HOST, array('transport' => $transport));
+        $data = array();
+        // test the request
+        $resp = $api->post('/test', $data);
+        $this->assertEquals($resp->status_code, 201);
+        $this->assertEquals($api->getJwt(), $jwt);
+    }
+
+
     function testPutIsPut()
     {
         // setup
@@ -159,6 +174,20 @@ class ApiTest extends TestCase {
         $this->assertTrue($resp instanceof \Requests_Response);
         $this->assertEquals($resp->body['request_payload']['key'], $request_data['key']);
         $this->assertEquals($resp->body['options']['type'], 'PUT');
+    }
+
+    function testPutUpdatesJwt()
+    {
+        $transport = new MockTransport();
+        $jwt = 'mock.jsonwebtoken.aasdf';
+        $transport->raw_headers =  'authorization: ' . $jwt ."\r\n";
+        $transport->code = 201;
+        $api = new Api(self::HOST, array('transport' => $transport));
+        $data = array();
+        // test the request
+        $resp = $api->put('/test', $data);
+        $this->assertEquals($resp->status_code, 201);
+        $this->assertEquals($api->getJwt(), $jwt);
     }
 
     function testPatchIsPatch()
@@ -175,6 +204,20 @@ class ApiTest extends TestCase {
         $this->assertEquals($resp->body['options']['type'], 'PATCH');
     }
 
+    function testPatchUpdatesJwt()
+    {
+        $transport = new MockTransport();
+        $jwt = 'mock.jsonwebtoken.aasdf';
+        $transport->raw_headers =  'authorization: ' . $jwt ."\r\n";
+        $transport->code = 201;
+        $api = new Api(self::HOST, array('transport' => $transport));
+        $data = array();
+        // test the request
+        $resp = $api->patch('/test', $data);
+        $this->assertEquals($resp->status_code, 201);
+        $this->assertEquals($api->getJwt(), $jwt);
+    }
+
     function testGetIsGet()
     {
         // setup
@@ -187,6 +230,20 @@ class ApiTest extends TestCase {
         $this->assertEquals($resp->body['options']['type'], 'GET');
     }
 
+    function testGetUpdatesJwt()
+    {
+        $transport = new MockTransport();
+        $jwt = 'mock.jsonwebtoken.aasdf';
+        $transport->raw_headers =  'authorization: ' . $jwt ."\r\n";
+        $transport->code = 201;
+        $api = new Api(self::HOST, array('transport' => $transport));
+        $data = array();
+        // test the request
+        $resp = $api->get('/test', $data);
+        $this->assertEquals($resp->status_code, 201);
+        $this->assertEquals($api->getJwt(), $jwt);
+    }
+
     function testDeleteIsDelete()
     {
         // setup
@@ -197,5 +254,19 @@ class ApiTest extends TestCase {
         $resp = $api->delete('/');
         $this->assertTrue($resp instanceof \Requests_Response);
         $this->assertEquals($resp->body['options']['type'], 'DELETE');
+    }
+
+    function testDeleteUpdatesJwt()
+    {
+        $transport = new MockTransport();
+        $jwt = 'mock.jsonwebtoken.aasdf';
+        $transport->raw_headers =  'authorization: ' . $jwt ."\r\n";
+        $transport->code = 201;
+        $api = new Api(self::HOST, array('transport' => $transport));
+        $data = array();
+        // test the request
+        $resp = $api->delete('/test', $data);
+        $this->assertEquals($resp->status_code, 201);
+        $this->assertEquals($api->getJwt(), $jwt);
     }
 }


### PR DESCRIPTION
now jwt should update whenever we make a request to our api.  

@lheddleston this fixes the bug we were seeing with the x_rurl not being in the jwt. 